### PR TITLE
Disable logging of all queries performed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.audit.winston-sequelize-transport",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.audit.winston-sequelize-transport",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/SequelizeTransport.js
+++ b/src/SequelizeTransport.js
@@ -110,6 +110,7 @@ class SequelizeTransport extends Transport {
       dialectOptions: {
         encrypt: opts.database.encrypt || true,
       },
+      logging: false,
     };
     if (opts.database.pool) {
       dbOpts.pool = opts.database.pool;


### PR DESCRIPTION
Changes:

- Turns off logging for all statements performed, errors will still be thrown but this removes the unnecessary `INSERT INTO [Table] PLACEHOLDER` in the console logs.
- Updates version in `package.json` and `package-lock.json` to the new latest version (3.2.0 as 3.1.0 is the current latest).